### PR TITLE
Clearer README.md;  Order Change in Section 1.3/1.4; Clearer 1.1

### DIFF
--- a/Holacracy-Constitution.md
+++ b/Holacracy-Constitution.md
@@ -42,13 +42,20 @@ You must capture and track all Projects and Next-Actions for your Role in a data
 
 Whenever you have time available to act in your Role, you must consider the potential Next-Actions you could efficiently and effectively do at that point in time, and execute whichever you believe would add the most value to the Organization from among that subset.
 
-### 1.3 Authority Over Domains
+### 1.3 Authority to Act
 
-As a Partner assigned to a Role, you have the authority to control and regulate each Domain of your Role.  You may do this on a case-by-case basis when others request permission to impact one of your Domains, by considering the request and allowing or withholding permission.  You may also define **_“Policies”_** for your Domains, which are either grants of authority that allow others to control or cause a material impact within a Domain, or limits on how others may do so when otherwise authorized.  Before a Policy is valid, you must first publish it in a forum convenient to all Partners who may be impacted.  The authorities granted to you in this section may be further limited by constraints defined under Section 2.1.3.
+As a Partner assigned to a Role, you have the authority to execute any Next-Actions you reasonably believe are necessary or desirable to express your Role’s Purpose or enact its Accountabilities.
 
-### 1.4 Authority to Act
+However, you cannot exert control or cause a material impact within a Domain owned by another Role or another sovereign entity, unless you have their permission.  The authority granted in this paragraph is further limited by Section 2.1.3.
 
-As a Partner assigned to a Role, you have the authority to execute any Next-Actions you reasonably believe are necessary or desirable to express your Role’s Purpose or enact its Accountabilities.  However, you can’t exert control or cause a material impact within a Domain owned by another Role or another sovereign entity, unless you have their permission.  The authority granted in this paragraph is further limited by Section 2.1.3.
+### 1.4 Authority Over Domains
+
+As a Partner assigned to a Role, you have the authority to control and regulate each Domain of your Role.  
+
+You may do this on a case-by-case basis when others request permission to impact one of your Domains, by considering the request and allowing or withholding permission.  You may also define **_“Policies”_** for your Domains, which are either grants of authority that allow others to control or cause a material impact within a Domain, or limits on how others may do so when otherwise authorized.  Before a Policy is valid, you must first publish it in a forum convenient to all Partners who may be impacted.
+
+The authorities granted to you in this section may be further limited by constraints defined under Section 2.1.3.
+
 
 ## Article II: Circle Structure
 
@@ -62,7 +69,7 @@ Each Circle must use the **_“Governance Process”_** described in Article III
 
 #### 2.1.2 Roles May Impact Circle Domains
 
-When filling a Role in a Circle, you may use and impact any Domain controlled by the Circle itself, or which the Circle is authorized to impact.  However, you may not fully control or regulate the Domain under the terms of Section 1.3, and you must abide by any constraints acting upon the Circle itself or defined by Policy of the Circle.  Further, you may not transfer or dispose of the Domain itself or any significant assets within the Domain, nor may you significantly limit any rights of the Circle to the Domain.  In all cases however, you may ignore these restrictions if a Role or process holding the needed authority grants you permission to do so.
+When filling a Role in a Circle, you may use and impact any Domain controlled by the Circle itself, or which the Circle is authorized to impact.  However, you may not fully control or regulate the Domain under the terms of Section 1.4, and you must abide by any constraints acting upon the Circle itself or defined by Policy of the Circle.  Further, you may not transfer or dispose of the Domain itself or any significant assets within the Domain, nor may you significantly limit any rights of the Circle to the Domain.  In all cases however, you may ignore these restrictions if a Role or process holding the needed authority grants you permission to do so.
 
 #### 2.1.3 Delegation of Control
 

--- a/Holacracy-Constitution.md
+++ b/Holacracy-Constitution.md
@@ -7,13 +7,13 @@ This **_“Constitution”_** defines rules and processes for the governance and
 
 ## Article I: Energizing Roles
 
-### 1.1 Definition of Role
+### 1.1 Definition of a Role
 
 The Organization’s Partners will typically perform work for the Organization by acting in an explicitly defined Role.  A **_“Role”_** is an organizational construct with a descriptive name and one or more of the following:
 
-- **(a)**	a **_“Purpose”_**, which is a capacity, potential, or unrealizable goal that the Role will pursue or express on behalf of the Organization; and/or
-- **(b)**	one or more **_“Domains”_**, which are those things the Role may exclusively control and regulate as its property, on behalf of the Organization; and/or
-- **(c)**	one or more **_“Accountabilities”_**, which are ongoing activities of the Organization that the Role will breakdown and enact.
+- **(a)**	a **_“Purpose”_**, which is a capacity, potential, or unrealizable goal that the Role will pursue or express on behalf of the Organization.
+- **(b)**	one or more **_“Domains”_**, which are things the Role may exclusively control and regulate as its property, on behalf of the Organization.
+- **(c)**	one or more **_“Accountabilities”_**, which are ongoing activities of the Organization that the Role will enact.
 
 ### 1.2 Responsibilities of Role-Filling
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,23 @@
 # Introduction: Holacracy® Constitution
 
-### What is this document?
+### What is the Holacracy Constitution?
 
-This Constitution documents the core rules, structure, and processes of the Holacracy “operating system” for governing and managing an organization. It provides a critical foundation for an organization wishing to use Holacracy, by anchoring the shift of power required in concrete and documented “rules of the game”, which everyone involved can reference and rely upon.
+The Holacracy Constitution documents the core rules, structure, and processes of the Holacracy “operating system” for governing and managing an organization. It provides the foundation for an organization wishing to use Holacracy, by anchoring the shift of power required in concrete and documented “rules of the game”, which everyone involved can rely upon.
 
-### How is this document intended to be used?
-This Constitution is intended to be referenced by whatever declaration or agreement captures the decision to organize using the Holacracy system. That may be a formal set of legal bylaws or similar operating agreement, or a simple board resolution or CEO policy declaration similar to the <a href="https://github.com/holacracyone/Holacracy-Constitution/blob/master/Adoption%20Declaration%20Sample.pdf" target="_blank">sample one attached here</a>. See Article V for key adoption-related matters, and note also that this explanatory page and the sample declaration are included for informative purposes but do not constitute part of the core Constitution document.
+### How is the Holacracy Constitution intended to be used?
+The Constitution is intended to be referenced by whatever declaration or agreement captures the decision to organize using the Holacracy system. That may be a formal set of legal bylaws or similar operating agreement, or a simple board resolution or CEO policy declaration similar to the <a href="https://github.com/holacracyone/Holacracy-Constitution/blob/master/Adoption%20Declaration%20Sample.pdf" target="_blank">sample one attached here</a>. See Article V for key adoption-related matters. Also note that this explanatory page and the sample declaration are included for informative purposes but do not constitute part of the core Constitution document.
 
-### What this document isn’t
-This document is not a complete set of legal bylaws or a formal operating agreement, although HolacracyOne separately publishes its own operating agreement as an example of a legal governing document that references and incorporates this Constitution. Nor is this document for learning to actually use the Holacracy system – like the rulebook for a nuanced sport, it can serve as a critical reference at times, but reading it will not teach you how to play the game. If you're looking for an introduction, check out our <a href="http://holacracy.org/how-it-works" target="_blank">How It Works</a> page and our <a href="http://holacracy.org/resources/video-introduction-to-holacracy" target="_blank">Introductory Video</a>.
+### What the Holacracy Constitution isn’t
+The Holacracy Constitution is **not a complete set of legal bylaws or a formal operating agreement**. (HolacracyOne separately publishes its own operating agreement as an example of a legal governing document that references and incorporates this Constitution.)
+
+The Constitution is also **not an instruction manual or a guidebook** for learning to actually use the Holacracy system: Like the rulebook for a nuanced sport, it can serve as a critical reference at times, but reading it will not teach you how to play the game. If you're looking for an introduction, check out HolacracyOne's <a href="http://holacracy.org/how-it-works" target="_blank">How It Works</a> page and this <a href="http://holacracy.org/resources/video-introduction-to-holacracy" target="_blank">Introductory Video</a>.
+
 
 ### Legal Disclaimer
 HolacracyOne is not a law firm. The information contained herein is documentation of Holacracy’s rules and processes, and should not be construed as legal advice to be applied to any specific factual situation. You should not rely upon the materials provided in this document in a legal capacity or for legal needs without first consulting an attorney with respect to your specific situation. This document is provided "as-is", without warranty or condition of any kind whatsoever. HolacracyOne does not warrant this document’s quality, accuracy, timeliness, completeness, merchantability, or fitness for use or purpose. To the maximum extent provided by law, HolacracyOne and its agents and members shall not be liable for any damages whatsoever arising from the use of this document.
 
 ### Licensing and Usage
-Like Linux®, Wikipedia®, and Java®, Holacracy® is a registered trademark; in this case, of HolacracyOne LLC.  And like other stewards of open platforms, HolacracyOne aims to maintain the integrity of its brand and the quality of what it represents.  So, we invite you to make and share your own derivative works of the Holacracy® Constitution, per the terms of our open-source CC BY-SA 4.0 license, and to reference that your work is derived from the official Holacracy Constitution - please include a link to http://holacracy.org/constitution.  However, beyond that reference, you may not name or otherwise brand your derivative work using the Holacracy mark, to avoid confusion between your version and the official Holacracy document.  If you have any questions, please <a href="http://www.holacracy.org/contact/" target="_blank">contact us</a>!
+Like Linux®, Wikipedia®, and Java®, Holacracy® is a registered trademark; in this case, of HolacracyOne LLC. And like other stewards of open platforms, HolacracyOne aims to maintain the integrity of its brand and the quality of what it represents. So, we invite you to make and share your own derivative works of the Holacracy® Constitution, per the terms of our open-source CC BY-SA 4.0 license, and to reference that your work is derived from the official Holacracy Constitution - please include a link to http://holacracy.org/constitution. However, beyond that reference, you may not name or otherwise brand your derivative work using the Holacracy mark, to avoid confusion between your version and the official Holacracy document. If you have any questions, please <a href="http://www.holacracy.org/contact/" target="_blank">contact HolacracyOne</a>!
 
 ---
 
@@ -42,7 +45,7 @@ The circle members of a circle rely on each other to help get their operational 
 
 #### [Article V: Adoption Matters] (https://github.com/holacracyone/Holacracy-Constitution/blob/master/Holacracy-Constitution.md#article-v-adoption-matters)
 
-This article deals with the transition from pre-Holacracy to operating under this Constitution, and provides rules when adopting Holacracy within a board structure with a group of representatives in lieu of a single Lead Link.
+This article deals with the transition from pre-Holacracy to operating under the Constitution, and provides rules when adopting Holacracy within a board structure with a group of representatives in lieu of a single Lead Link.
 
 ---
 


### PR DESCRIPTION
The usage of "this document" was confusing to me, as "this document" (README.md) was actually speaking about the Holacracy Constitution, and not about itself. I made changes that fix that, and added some minor edits for brevity and clarity. Also changed some usages of "us" to "HolacracyOne" to allow for easier reusability of the document by others.
