### PR TITLE
Clarify priorities to be relative not absolute

### DIFF
--- a/Holacracy-Constitution.md
+++ b/Holacracy-Constitution.md
@@ -85,7 +85,7 @@ A Circle’s Lead Link inherits any Accountabilities and controls any Domains de
 
 #### 2.2.2 Defines Priorities & Strategies
 
-A Circle’s Lead Link may define priorities for the Circle.  In addition, the Lead Link may define more general heuristics for prioritization, which guide the Circle’s Roles in self-identifying priorities on a case-by-case basis (each general heuristic is a **_“Strategy”_** of the Circle).
+A Circle’s Lead Link may define relative priorities for the Circle.  In addition, the Lead Link may define more general heuristics for prioritization, which guide the Circle’s Roles in self-identifying priorities on a case-by-case basis (each general heuristic is a **_“Strategy”_** of the Circle).
 
 #### 2.2.3 Amending Lead Link Role
 


### PR DESCRIPTION
Article 2.2.2 states a Lead Link may define priorities for the Circle. I would suggest to specify a Lead Link can define _relative_ priorities for the Circle, not _absolute_ priorities, similar to the use in article 4.1.1 b). See http://fabiopereira.me/blog/2009/06/29/principle-of-relative-priority/ for a brief discussion of the difference between relative and absolute priorities.
