### PR TITLE
Reword the Role definition, Domain can be facultative

### DIFF
--- a/Holacracy-Constitution.md
+++ b/Holacracy-Constitution.md
@@ -12,7 +12,7 @@ This **_“Constitution”_** defines rules and processes for the governance and
 The Organization’s Partners will typically perform work for the Organization by acting in an explicitly defined Role. A **_“Role”_** is an organizational construct with a descriptive name and one or more of the following:
 
 - **(a)** a **_“Purpose”_**, which is a capacity, potential, or unrealizable goal that the Role will pursue or express on behalf of the Organization.
-- **(b)** one or more **_“Domains”_**, which are things the Role may exclusively control and regulate as its property, on behalf of the Organization.
+- **(b)** zero, one or more **_“Domains”_**, which are things the Role may exclusively control and regulate as its property, on behalf of the Organization.
 - **(c)** one or more **_“Accountabilities”_**, which are ongoing activities of the Organization that the Role will enact.
 
 ### 1.2 Responsibilities of Role-Filling


### PR DESCRIPTION
There is no need to have a domain defined for every role, the previous definition was saying "one or more Domains", this was subject to wrong interpretation
