### PR TITLE
Simplify language in 2.3.2, second attempt

### DIFF
--- a/Holacracy-Constitution.md
+++ b/Holacracy-Constitution.md
@@ -128,7 +128,7 @@ Unless a special appointment or exclusion is made under the terms of this sectio
 
 If multiple Partners are assigned to the same Defined Role in a Circle, the Circle may enact a Policy that limits how many of them are Core Circle Members as a result of that Role assignment. However, the Policy must allow at least one of the Partners filling the Role to represent it as a Core Circle Member, and must specify how that representative will be determined.
 
-In addition, any Partners representing the Role have the duty to consider and process Tensions conveyed by the excluded Partners, exactly as a Rep Link would were the Role a Sub-Circle, unless the Policy defines an alternate pathway for the excluded Partners to process Tensions related to that Role.
+In addition, any Partners representing the Role have the duty to consider and process Tensions conveyed by the excluded Partners, exactly as a Rep Link would if the Role were a Sub-Circle. A Policy may define an alternate pathway for the excluded Partners to process Tensions related to that Role.
 
 #### 2.3.3 Exclusion for Minor Allocations
 

--- a/Holacracy-Constitution.md
+++ b/Holacracy-Constitution.md
@@ -128,7 +128,7 @@ Unless a special appointment or exclusion is made under the terms of this sectio
 
 If multiple Partners are assigned to the same Defined Role in a Circle, the Circle may enact a Policy that limits how many of them are Core Circle Members as a result of that Role assignment. However, the Policy must allow at least one of the Partners filling the Role to represent it as a Core Circle Member, and must specify how that representative will be determined.
 
-In addition, any Partners representing the Role have the duty to consider and process Tensions conveyed by the excluded Partners, exactly as a Rep Link would if the Role were a Sub-Circle. A Policy may define an alternate pathway for the excluded Partners to process Tensions related to that Role.
+The Policy can define a pathway for the excluded Partners to process Tensions related to that Role. If it does not, any Partners representing the Role have the duty to consider and process Tensions conveyed by the excluded Partners, exactly as a Rep Link would if the Role were a Sub-Circle.
 
 #### 2.3.3 Exclusion for Minor Allocations
 


### PR DESCRIPTION
Brian was right in rejecting the change in https://github.com/holacracyone/Holacracy-Constitution/pull/79 as it would change the intended meaning (thank you!). Here is a new attempt: It breaks the long sentence up into two and changes the order of how the information is given. It maintains the simple language change around the "were". To me, this reads more easily. @bernardmariechiquet @brianjrobertson : what do you think?
