### PR TITLE
Simplify 3.3: Secretary's duty for scheduling of Governance Meetings

### DIFF
--- a/Holacracy-Constitution.md
+++ b/Holacracy-Constitution.md
@@ -342,7 +342,7 @@ When an Objection to a Proposal is raised, the following additional rules apply 
 
 The Secretary of a Circle is responsible for scheduling Governance Meetings to enact the Circle’s Governance Process.
 
-In addition to any regular, recurring Governance Meetings the Secretary schedules, the Secretary is responsible for scheduling additional special Governance Meetings promptly upon request of any Core Circle Member. 
+The Secretary must schedule a Governance Meeting promptly upon request of any Core Circle Member. 
 
 The Facilitator is responsible for presiding over all Governance Meetings in alignment with the following rules and any relevant Policies of the Circle.
 


### PR DESCRIPTION
A simple, rough attempt at addressing the question in https://github.com/holacracyone/Holacracy-Constitution/issues/60 : In my view, this could be very simple; and left to the organisation to make Policy around "regularity" of meetings. This simplifies the practise and removes the confusion about what "regular" meetings are.
