### PR TITLE
Lead Links can revoke role assignments

### DIFF
--- a/Holacracy-Constitution.md
+++ b/Holacracy-Constitution.md
@@ -142,15 +142,15 @@ The Lead Link of a Circle may specially appoint additional persons to serve as C
 
 ### 2.4 Role Assignment
 
-The Lead Link of a Circle may assign people to fill Defined Roles in the Circle, unless that authority has been limited or delegated.
+The Lead Link of a Circle may assign Partners to fill Defined Roles in the Circle and revoke these assignments at any time, unless these authorities has been limited or delegated.
 
 #### 2.4.1 Unfilled Roles
 
 Whenever a Defined Role in a Circle is unfilled, the Circle’s Lead Link is considered to be filling the Role.
 
-#### 2.4.2 Assigning Roles to Multiple People
+#### 2.4.2 Assigning Roles to Multiple Partners
 
-A Lead Link may assign multiple people to the same Defined Role, as long as that will not decrease the clarity of who should enact the Accountabilities and authorities of the Role in common situations.
+A Lead Link may assign multiple Partners to the same Defined Role, as long as that will not decrease the clarity of who should enact the Accountabilities and authorities of the Role in common situations.
 
 As one way of maintaining that clarity, a Lead Link may specify a “Focus” along with each assignment, which is an area or context for that person to focus within while executing in the Role.
 


### PR DESCRIPTION
This pull request is based on a topic on the community of practice: http://community.holacracy.org/topic/can-lead-links-unassign-individuals-from-roles
It seems to me that the constitution is not explicit on the fact that the Lead Link can in fact revoke the assignment of a role to an individual. This causes confusion - as the LL role description seems in conflict with the 2.4 section of the constitution itself.

I suggest four changes to the constitution:
1.  Adding "and revoke these assignments", because this is the dominant interpretation (judged by the discussion on the community) and the way the LL role is defined: It has domain over "Role assignments within the Circle".
2.  Adding "at any time" to stress that the LL (per default) does not need to seek consensus or approval from anyone or any process.
3.  Changing to a plural "authorities" as it is not just the authority to assign nor the authority to revoke assignments, that might be limited or delegated.
4.  Changing "people" to "Partners" as this is used instead of "people" or "individuals" throughout the constitution, and I imagine that a LL would not like to assign a role to an individual that does not "agree to take part in the governance and operations of the Organization" (from the definition of a Partner).

Side-note: I would actually like if the wording around assigning people to roles were "invite to roles", at least this is how we interpret the constitution, as in fact the person being assigned can resign at any given time and we like the Lead Link to go through the role description to make sure the person understrands the accountabilities they are taking upon themselves. But this might be an entirely different pull-request :)
