### PR TITLE
Lead Links can revoke role assignments

### DIFF
--- a/Holacracy-Constitution.md
+++ b/Holacracy-Constitution.md
@@ -142,7 +142,7 @@ The Lead Link of a Circle may specially appoint additional persons to serve as C
 
 ### 2.4 Role Assignment
 
-The Lead Link of a Circle may assign people to fill Defined Roles in the Circle, unless that authority has been limited or delegated.
+The Lead Link of a Circle may assign people to fill Defined Roles in the Circle and revoke these assignments at any time, unless these authorities have been limited or delegated.
 
 #### 2.4.1 Unfilled Roles
 


### PR DESCRIPTION
This pull request is based on a topic on the community of practice: http://community.holacracy.org/topic/can-lead-links-unassign-individuals-from-roles
It seems to me that the constitution is not explicit on the fact that the Lead Link can in fact revoke the assignment of a role to an individual. This causes confusion - as the LL role description seems in conflict with the 2.4 section of the constitution itself.

I suggest four changes to the constitution:
1. Adding "and revoke these assignments", because this is the dominant interpretation (judged by the discussion on the community) and the way the LL role is defined: It has domain over "Role assignments within the Circle".
2. Adding "at any time" to stress that the LL (per default) does not need to seek consensus or approval from anyone or any process.
3. Changing to a plural "authorities" as it is not just the authority to assign nor the authority to revoke assignments, that might be limited or delegated.
