### PR TITLE
purpose description aligned with glassfrog (1.1a)

### DIFF
--- a/Holacracy-Constitution.md
+++ b/Holacracy-Constitution.md
@@ -11,7 +11,7 @@ This **_“Constitution”_** defines rules and processes for the governance and
 
 The Organization’s Partners will typically perform work for the Organization by acting in one or more explicitly defined Roles. A **_“Role”_** is an organizational construct with a descriptive name and one or more of the following:
 
-- **(a)** a **_“Purpose”_**, which is a capacity, potential, or unrealizable goal that the Role will pursue or express on behalf of the Organization. The purpose helps to define an "identity" of the role.
+- **(a)** a **_“Purpose”_**, which is a capacity, potential, or unrealizable goal that the Role will pursue or express on behalf of the Organization.
 - **(b)** one or more **_“Domains”_**, which are things the Role may exclusively control and regulate as its property, on behalf of the Organization.
 - **(c)** one or more **_“Accountabilities”_**, which are ongoing activities of the Organization that the Role will enact.
 

--- a/Holacracy-Constitution.md
+++ b/Holacracy-Constitution.md
@@ -11,7 +11,7 @@ This **_“Constitution”_** defines rules and processes for the governance and
 
 The Organization’s Partners will typically perform work for the Organization by acting in one or more explicitly defined Roles. A **_“Role”_** is an organizational construct with a descriptive name and one or more of the following:
 
-- **(a)** a **_“Purpose”_**, which is a capacity, potential, or unrealizable goal that the Role will pursue or express on behalf of the Organization.
+- **(a)** a **_“Purpose”_**, which is a capacity, potential, or unrealizable goal that the Role will pursue or express on behalf of the Organization. The purpose helps to define an "identity of the role.
 - **(b)** one or more **_“Domains”_**, which are things the Role may exclusively control and regulate as its property, on behalf of the Organization.
 - **(c)** one or more **_“Accountabilities”_**, which are ongoing activities of the Organization that the Role will enact.
 

--- a/Holacracy-Constitution.md
+++ b/Holacracy-Constitution.md
@@ -467,10 +467,10 @@ When filling a Role in a Circle, you have the following duties to your fellow Ci
 
 You have a duty to provide transparency when requested by your fellow Circle Members, in any of the following areas:
 
-- **(a) Projects & Next-Actions:** You must share any Projects and Next-Actions you are tracking for your Roles in the Circle.
-- **(b) Relative Priority:** You must share your judgment of the relative priority of any Projects or Next-Actions tracked for your Roles in the Circle, vs. any other potential activities competing for your attention or resources.
-- **(c) Projections:** You must provide a projection of the date you expect to complete any Project or Next-Action tracked for any of your Roles in the Circle. A rough estimate is sufficient, considering your current context and priorities, but without detailed analysis or planning. This projection is not a binding commitment in any way, and unless Governance says otherwise, you have no duty to track the projection, manage your work to achieve it, or follow-up with the recipient if something changes.
-- **(d) Checklist Items & Metrics:** You must share whether you have completed any regular, recurring actions that you routinely perform in service of your Roles in the Circle. You must also track and report on any metrics assigned to your Roles by the Circle’s Lead Link, or by any other Role or process granted the authority to define the Circle’s metrics.
+- **(a) Projects & Next-Actions:** Share any Projects and Next-Actions you are tracking for your Roles in the Circle.
+- **(b) Relative Priority:** Share your judgment of the relative priority of any Projects or Next-Actions tracked for your Roles in the Circle, vs. any other potential activities competing for your attention or resources.
+- **(c) Projections:** Provide a projection of the date you expect to complete any Project or Next-Action tracked for any of your Roles in the Circle. A rough estimate is sufficient, considering your current context and priorities, but without detailed analysis or planning. This projection is not a binding commitment in any way, and unless Governance says otherwise, you have no duty to track the projection, manage your work to achieve it, or follow-up with the recipient if something changes.
+- **(d) Checklist Items & Metrics:** Share whether you have completed any regular, recurring actions that you routinely perform in service of your Roles in the Circle. You must also track and report on any metrics assigned to your Roles by the Circle’s Lead Link, or by any other Role or process granted the authority to define the Circle’s metrics.
 
 #### 4.1.2 Duty of Processing
 

--- a/Holacracy-Constitution.md
+++ b/Holacracy-Constitution.md
@@ -11,7 +11,7 @@ This **_“Constitution”_** defines rules and processes for the governance and
 
 The Organization’s Partners will typically perform work for the Organization by acting in one or more explicitly defined Roles. A **_“Role”_** is an organizational construct with a descriptive name and one or more of the following:
 
-- **(a)** a **_“Purpose”_**, which is a capacity, potential, or unrealizable goal that the Role will pursue or express on behalf of the Organization. The purpose helps to define an "identity of the role.
+- **(a)** a **_“Purpose”_**, which is a capacity, potential, or unrealizable goal that the Role will pursue or express on behalf of the Organization. The purpose helps to define an "identity" of the role.
 - **(b)** one or more **_“Domains”_**, which are things the Role may exclusively control and regulate as its property, on behalf of the Organization.
 - **(c)** one or more **_“Accountabilities”_**, which are ongoing activities of the Organization that the Role will enact.
 


### PR DESCRIPTION
In glassfrog (on the role page behind the question mark next to purpose on the top left) there is a pragmatic description of what a purpose is that I hear frequently quoted. propose to add it here for clarity and alignment with real life practice.
