### PR TITLE
Fix headers markup for the sake of strict Markdown parsers

### DIFF
--- a/Holacracy-Constitution.md
+++ b/Holacracy-Constitution.md
@@ -1,7 +1,7 @@
-#**Holacracy Constitution - Development Version**
+# **Holacracy Constitution - Development Version**
 
 
-##Preamble
+## Preamble
 
 This **_“Constitution”_** defines rules and processes for the governance and operations of an organization. The **_“Ratifiers”_** are adopting these rules as the formal authority structure for the **_“Organization”_** specified upon the Constitution’s adoption, which may be an entire entity or a part of one that the Ratifiers have authority to govern and run. The Ratifiers and anyone else who agrees to take part in the governance and operations of the Organization (its **_“Partners”_**) may rely upon the authorities granted by this Constitution, and also agree to be bound by its duties and constraints.
 


### PR DESCRIPTION
CommonMark spec (http://spec.commonmark.org/0.27/#atx-headings) says
that the hashes must be followed by a space, so some parsers
don't recognize two first headers as headers.