### PR TITLE
Update Appendix-AL.md

### DIFF
--- a/Appendix-A.md
+++ b/Appendix-A.md
@@ -43,7 +43,7 @@ _The Lead Link also holds all un-delegated Circle-level Domains and Accountabili
 **Accountabilities:**
 
 - Facilitating the Circle’s constitutionally-required meetings
-- Auditing the meetings and records of Sub-Circles as needed, and declaring a Process Breakdown upon discovering a pattern of behavior that conflicts with the rules of the Constitution
+- Auditing the meetings and records of Sub-Circles on request, and declaring a Process Breakdown upon discovering a pattern of behavior that conflicts with the rules of the Constitution
 
 
 ###Secretary


### PR DESCRIPTION
We have come across different interpretations of the Facilitators Acc "Auditing the meetings and records of Sub-Circles as needed, and declaring a Process Breakdown upon discovering a pattern of behavior that conflicts with the rules of the Constitution".
Especially the question if this can be expected (eg to derive a project as part of Fac weekly review) to audit records of sub-circles on an ongoing basis was questioned. The marker "as needed" indicates that it's somehow based on a specific tension rather than implying a "kind of" controlling mentality by auditing records of the sub on a continuous base.
It could be a bit clearer, maybe by substituting "as needed" by "on request" or a similar expression that helps to understand that there is a triggering event/tension.