### PR TITLE
Update Holacracy-Constitution.md

### DIFF
--- a/Holacracy-Constitution.md
+++ b/Holacracy-Constitution.md
@@ -323,9 +323,10 @@ However, when assessing the validity of a Proposal, the Facilitator may only jud
 Some Tensions do not count as Objections, and may be ignored during the processing of a Proposal. A Tension only counts as an Objection if it meets **all** of the criteria defined in (a) through (d) below, or the special criteria defined in (e):
 
 - **(a)** If the Tension were unaddressed, the capacity of the Circle to express its Purpose or enact its Accountabilities would degrade. Thus, the Tension is not just triggered by a better idea or a potential for further improvement, but because the Proposal would actually move the Circle backwards in its current capacity. For this criteria, decreasing clarity counts as degrading capacity, although merely failing to improve clarity does not.
-- **(b)** The Tension does not already exist for the Circle even in the absence of the Proposal. Thus, the Tension would be created specifically by adopting the Proposal, and would not exist were the Proposal withdrawn.
-- **(c)** The Tension is triggered just by presently known facts or events, without regard to a prediction of what might happen in the future. However, relying on predictions is allowed when no opportunity to adequately sense and respond is likely to exist in the future before significant impact could result.
-- **(d)** The Tension limits the Objector's capacity to express the Purpose or an Accountability of a Role in the Circle that the Objector either represents or has received permission to represent from a Role Representative who normally represents the Role.
+- **(b)** The Tension limits the Objector's capacity to express the Purpose or an Accountability of a Role in the Circle that the Objector either represents or has received permission to represent from a Role Representative who normally represents the Role.
+- **(c)** The Tension does not already exist for the Circle even in the absence of the Proposal. Thus, the Tension would be created specifically by adopting the Proposal, and would not exist were the Proposal withdrawn.
+- **(d)** The Tension is triggered just by presently known facts or events, without regard to a prediction of what might happen in the future. However, relying on predictions is allowed when no opportunity to adequately sense and respond is likely to exist in the future before significant impact could result.
+
 
 However, regardless of the above criteria, a Tension about adopting a Proposal always counts as an Objection if:
 


### PR DESCRIPTION
In my experience, it's far more common for an objection to be invalidated because it doesn't fit one of the objector's roles, rather than because it's predictive. It is also a more important learning point ("Is the tension felt in a role you fill?") for early practice. However, the current version of the Constitution sequences the criteria in such a way that many Facilitators ask the predictive question (and all of its nuanced explanations) when if the Facilitator had just asked the role-based question, it would have likely been invalidated. So, I'm proposing a simple re-ordering of the criteria to make it easier for Facilitators to apply the test questions