### PR TITLE
Elections & Eligibility

### DIFF
--- a/Holacracy-Constitution.md
+++ b/Holacracy-Constitution.md
@@ -90,7 +90,7 @@ Each Circle with more than one Partner filling its Roles automatically includes 
 
 #### 1.6.1 Elections & Eligibility
 
-The Facilitator of a Circle will facilitate elections using the process and rules defined in Article 3 to elect one person into its Facilitator Role and one into its Secretary Role. No Role or Policy may assign these Roles or remove an assignment via any other means, nor modify the required process. The only candidates normally eligible for these elections are those Partners filling Roles within the Circle. However, a Policy of the Circle or any Circle ultimately containing the Circle may allow additional candidates or further limit the candidates eligible for election.
+The Facilitator of a Circle will facilitate elections using the process and rules defined in Article 3 to elect one person into its Facilitator Role and one into its Secretary Role. No Role or Policy may assign these Roles or remove an assignment via any other means, nor modify the required process. The only candidates normally eligible for these elections are those Partners filling Roles within the Circle. However, a Policy of the Circle or any Circle ultimately containing the Circle may allow additional candidates and/or further limit the candidates eligible for election.
 
 #### 1.6.2 Election Term
 


### PR DESCRIPTION
For the eligibility of the Secretary and Facilitator, it's written “_However, a Policy of the Circle or any Circle ultimately containing the Circle may allow additional candidates or further limit the candidates eligible for election._”, I'd just like to clarify that both are possibles, given the fact that sometimes you may have a policy allowing candidates which aren't Circle Members and also restrict from making some Partners eligible (mostly thinking about one of the App we got for putting Facilitator badges in place).