### PR TITLE
proposed patch for #333

### DIFF
--- a/Holacracy-Constitution.md
+++ b/Holacracy-Constitution.md
@@ -152,7 +152,7 @@ You may not exert control or cause a material impact on a Domain delegated to a 
 
 When you need permission to impact a Domain, you may get it from whomever controls that Domain. You may also get permission by announcing your intent to take a specific action, and inviting anyone with a relevant Domain to object. You must then wait a reasonable time to allow responses. If no one objects in that time, you then have permission to impact any Domains owned by any Role in the Organization that your announcement reached. You may assume a written announcement reached anyone who typically reads messages in the channel you used. Any permission so granted only applies while taking the specific action you announced. A Policy may change or constrain this process.
 
-#### 2.1.3 Don't Spend Money
+#### 2.1.3 Spending Circle Resources
 
 While energizing your Role, you may not spend any money or other assets unless you first get authorized to do so. This authorization must come from a Circle that already has control of those resources for spending purposes. It counts as spending if you dispose of significant property of the Circle, or significantly limit any of its rights.
 


### PR DESCRIPTION
renamed 2.1.3 to "Spending Circle Resources" instead of "Don't Spend Money" to :
- generalize beyond money
- reflect the fact that it's a process that deals with spending rather than forbiding it