### PR TITLE
Being able to add accountabilities to the anchor circle

### DIFF
--- a/Holacracy-Constitution.md
+++ b/Holacracy-Constitution.md
@@ -80,7 +80,7 @@ Granting a Domain to a Role does not delegate any rights the Circle has to contr
 
 #### 1.4.3 Anchor Circle
 
-The broadest Circle that holds the Purpose of the whole Organization is its ***“Anchor Circle”***. The Anchor Circle holds all authorities and Domains that the Organization itself controls, and has no Super-Circle and no Accountabilities. The Anchor Circle may change its own Purpose via a Policy.
+The broadest Circle that holds the Purpose of the whole Organization is its ***“Anchor Circle”***. The Anchor Circle holds all authorities and Domains that the Organization itself controls, and has no Super-Circle. The Anchor Circle may change its own Purpose via a Policy.
 
 The Ratifiers may define an initial structure and other Governance within the Anchor Circle upon adopting this Constitution.
 


### PR DESCRIPTION
In [1.4.3](https://github.com/holacracyone/Holacracy-Constitution/blob/master/Holacracy-Constitution.md#143-anchor-circle), it's specified “_The Anchor Circle holds all authorities and Domains that the Organization itself controls, and has no Super-Circle and no Accountabilities._”. With some clients, we find it useful to be able to add accountabilities to the anchor circle. I'll give an example: A company of 100 people with a Directory. The Directory is the one ratifying the Constitution, and they legally have a Supervision Council above them, and it made sense for the Directory to explicit on the Anchor Circle (so the Directory) the accountabilities that Supervision Council had on the Directory, and it allowed to communicate them to the entire organisation and make them be transparent, even as the Supervision Council didn't ratified the Holacracy Constitution, but just made sense.