### PR TITLE
be warned if a Partner leaves a relational agreement

### DIFF
--- a/Holacracy-Constitution.md
+++ b/Holacracy-Constitution.md
@@ -257,7 +257,7 @@ As a Partner, you may have ***“Relational Agreements”*** with other Partners
 
 Relational Agreements must remain focused on shaping behaviors that generally underpin work; they may not set expectations of work to do in a Role, nor expectations about how a Partner will prioritize across different Roles. Further, they may only specify concrete acts to do or behavioral constraints to honor; they may not include promises to achieve specific outcomes or embody abstract qualities.
 
-As a Partner, you may request a Relational Agreement of another Partner for your own personal preferences or to serve a Role you fill. That Partner may accept or reject the requested Relational Agreement based on their own personal preferences. Either party may later terminate the Relational Agreement without the consent of the other party, unless otherwise agreed.
+As a Partner, you may request a Relational Agreement of another Partner for your own personal preferences or to serve a Role you fill. That Partner may accept or reject the requested Relational Agreement based on their own personal preferences. Either party may later terminate the Relational Agreement without the consent of the other party by notifying the other Partners in the agreement via an appropriate channel, unless otherwise agreed.
 
 As a Partner, you have a duty to align your behavior with any written Relational Agreements you have made. Anyone facilitating a meeting or process for the Organization may also enforce these Relational Agreements during that meeting or process, as long as they don't conflict with anything defined in this Constitution.
 


### PR DESCRIPTION
Having practiced these relational agreements for a year, I can say that it is very important to be warned if a Partner leaves a relational agreement! Otherwise, one can discover by surprise that an associate has decided, one does not know when, not to respect such an agreement anymore.